### PR TITLE
UStVA Export akzeptiert bisher das Jahr 2019 nicht

### DIFF
--- a/VatReportGermany2016/geierlein.js
+++ b/VatReportGermany2016/geierlein.js
@@ -703,7 +703,7 @@ var validationRules = {
 
     jahr: [
         rules.required,
-        rules.range(2010, 2018)
+        rules.range(2010, 2019)
     ],
 
     zeitraum: [


### PR DESCRIPTION
Dieser PR ändert lediglich das akzeptierte Jahr auf bis zu 2019.